### PR TITLE
Miscellaneous updates for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ PYTHON ?= python3
 
 @PHONEY: clean
 clean:
-	mkdir -p dist
-	rm -r dist
+	rm -rf dist
 
 @PHONEY: build
-build: clean requirements
+build: clean
+	$(PYTHON) -m pip install -U build
 	$(PYTHON) -m build  --wheel --sdist
 
 @PHONEY: install
@@ -15,4 +15,4 @@ install: build
 
 @PHONEY: requirements
 requirements:
-	pip install -r requirements.txt
+	$(PYTHON) -m pip install -r requirements.txt


### PR DESCRIPTION
- Building the package doesn't require installation of all requirements. Only [build](https://github.com/pypa/build) is needed.
- Calling `pip` from `python` (`python -m pip some_command`) to ensure things work in an environment that contains multiple Python versions.
- `-f` in `rm -rf dist` can make it ignore the non-existent directory.