### PR TITLE
Fixing ipv6 dataclass

### DIFF
--- a/linode_metadata/objects/networking.py
+++ b/linode_metadata/objects/networking.py
@@ -36,9 +36,9 @@ class IPv6Networking(ResponseBase):
     """
 
     slaac: str
-    link_local: List[str] = field(metadata={"json": "link-local"})
+    link_local: str = field(metadata={"json": "link_local"})
     ranges: List[str]
-    shared_ranges: List[str] = field(metadata={"json": "shared-ranges"})
+    shared_ranges: List[str] = field(metadata={"json": "shared_ranges"})
 
 
 @dataclass(init=False)


### PR DESCRIPTION
## 📝 Description

Fixes link_local and shared_ranges such that json matches what is returned from API.

## ✔️ How to Test

Manual Testing:
Go into Linode instance with py-metadata and create main.py file as follows:

```python
import os
from linode_metadata import MetadataClient

def main():
    client = MetadataClient()
    network_info = client.get_network()
    print("Link Local:", network_info.ipv6.link_local, "\n")
    print("Shared Ranges:", network_info.ipv6.shared_ranges, "\n")

if __name__ == "__main__":
    main()
```
Run `python3 main.py` and verify that link_local returns same value as Metadata Service API.
