### PR TITLE
fix: Resolve intermittent cloud-init readiness polling error

### DIFF
--- a/hack/run-e2e.yml
+++ b/hack/run-e2e.yml
@@ -84,7 +84,7 @@
           retries: 30
           delay: 5
           register: cloud_init_status
-          until: (cloud_init_status.stdout | from_json)["status"] == "done"
+          until: cloud_init_status.rc == 0 and (cloud_init_status.stdout | from_json)["status"] == "done"
 
         - name: Update repositories and install necessary packages
           become: yes


### PR DESCRIPTION
## 📝 Description

This change resolves the following issue that would cause occasional E2E test playbook failures during instance provisioning:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This error was the result of the `cloud-init status` command occasionally failing, so this change adds an additional return code check to the loop "until" logic.

Related to #15 

## ✔️ How to Test

1. Ensure any previous E2E test instances have been deleted.
2. Run the E2E test target

```
make e2e
```

3. Observe no error when polling for cloud-init.

