### PR TITLE
Switch HTTP library from requests to httpx

### DIFF
--- a/linode_metadata/__init__.py
+++ b/linode_metadata/__init__.py
@@ -1,6 +1,7 @@
 """
 Initializes objects for Metadata Client
 """
+
 from linode_metadata.objects import *
 
 from .metadata_client import MetadataClient

--- a/linode_metadata/metadata_client.py
+++ b/linode_metadata/metadata_client.py
@@ -2,6 +2,7 @@
 This class provides functions for interacting with the Linode Metadata service.
 It includes methods for retrieving and updating metadata information.
 """
+
 import base64
 import datetime
 import json

--- a/linode_metadata/objects/__init__.py
+++ b/linode_metadata/objects/__init__.py
@@ -1,6 +1,7 @@
 """
 Objects for API responses.
 """
+
 from .instance import *
 from .networking import *
 from .ssh_keys import *

--- a/linode_metadata/objects/error.py
+++ b/linode_metadata/objects/error.py
@@ -2,6 +2,7 @@
 Data classes related to error handling.
 """
 from builtins import super
+from typing import Optional
 
 
 class ApiError(RuntimeError):
@@ -11,10 +12,19 @@ class ApiError(RuntimeError):
     often, this will be caused by invalid input to the API.
     """
 
-    def __init__(self, message, status=400, json=None):
+    def __init__(
+        self, message: str, status: int = 400, json: Optional[dict] = None
+    ):
         super().__init__(message)
         self.status = status
         self.json = json
         self.errors = []
         if json and "errors" in json and isinstance(json["errors"], list):
             self.errors = [e["reason"] for e in json["errors"]]
+
+
+class ApiTimeoutError(RuntimeError):
+    """A Linode Metadata API call timeout error"""
+
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/linode_metadata/objects/error.py
+++ b/linode_metadata/objects/error.py
@@ -1,6 +1,7 @@
 """
 Data classes related to error handling.
 """
+
 from builtins import super
 from typing import Optional
 

--- a/linode_metadata/objects/instance.py
+++ b/linode_metadata/objects/instance.py
@@ -1,6 +1,7 @@
 """
 Data classes related to Linode instances.
 """
+
 from dataclasses import dataclass
 from typing import List, Optional
 

--- a/linode_metadata/objects/networking.py
+++ b/linode_metadata/objects/networking.py
@@ -1,6 +1,7 @@
 """
 Data classes related to Networking.
 """
+
 from dataclasses import dataclass, field
 from typing import List, Optional
 

--- a/linode_metadata/objects/response_base.py
+++ b/linode_metadata/objects/response_base.py
@@ -2,6 +2,7 @@
 This class is the base class for response classes.
 It includes basic methods for handling JSON responses.
 """
+
 import dataclasses
 from dataclasses import dataclass
 from typing import Any, Dict

--- a/linode_metadata/objects/ssh_keys.py
+++ b/linode_metadata/objects/ssh_keys.py
@@ -1,6 +1,7 @@
 """
 Data classes related to SSH Keys.
 """
+
 from dataclasses import dataclass
 from typing import Dict, List
 

--- a/linode_metadata/objects/token.py
+++ b/linode_metadata/objects/token.py
@@ -1,6 +1,7 @@
 """
 Data classes related to Metadata Service token.
 """
+
 from dataclasses import dataclass
 from datetime import datetime
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["requests"]
+dependencies = ["httpx"]
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## 📝 Description

This PR switch the Python HTTP library/client from `requests` to `httpx` for better asyncio support for the future development of asyncio related features.

## ✔️ How to Test
`make e2e`

