### PR TITLE
Wrap reusable components in `BaseMetadataClient`

### DIFF
--- a/linode_metadata/metadata_client.py
+++ b/linode_metadata/metadata_client.py
@@ -6,6 +6,7 @@ It includes methods for retrieving and updating metadata information.
 import base64
 import datetime
 import json
+from collections.abc import Awaitable
 from datetime import datetime, timedelta
 from importlib.metadata import version
 from typing import Any, Callable, Optional, Union
@@ -23,7 +24,167 @@ BASE_URL = "http://169.254.169.254/v1"
 DEFAULT_API_TIMEOUT = 10
 
 
-class MetadataClient:
+class BaseClient:
+    def __init__(
+        self,
+        base_url=BASE_URL,
+        user_agent=None,
+        token=None,
+        timeout=DEFAULT_API_TIMEOUT,
+        managed_token=True,
+        managed_token_expiry_seconds=3600,
+    ):
+        """
+        The main interface to the Linode Metadata Service.
+
+        :param base_url: The base URL for Metadata API requests.  Generally, you shouldn't
+                         change this.
+        :type base_url: str
+        :param user_agent: What to append to the User Agent of all requests made
+                           by this client.  Setting this allows Linode's internal
+                           monitoring applications to track the usage of your
+                           application.  Setting this is not necessary, but some
+                           applications may desire this behavior.
+        :type user_agent: str
+        :param token: An existing token to use with this client. This field cannot
+                      be specified when token management is enabled.
+        :type token: Optional[str]
+        :param managed_token: If true, the token for this client will be automatically
+                              generated and refreshed.
+        :type managed_token: bool
+        :type managed_token_expiry_seconds: The number of seconds until a managed token
+                                            should expire. (Default 3600)
+        :type managed_token_expiry_seconds: int
+        """
+
+        if token is not None and managed_token:
+            raise ValueError(
+                "Token cannot be specified with token management is enabled"
+            )
+
+        self.base_url = base_url
+        self._append_user_agent = user_agent
+        self.timeout = timeout
+
+        self._token = token
+        self.client = None
+
+        self._managed_token = managed_token
+        self._managed_token_expiry_seconds = managed_token_expiry_seconds
+        self._managed_token_expiry = None
+
+    @staticmethod
+    def _parse_response_body(response: Response, content_type: str) -> Any:
+        handlers = {
+            "application/json": response.json,
+            "text/plain": lambda: response.content,
+        }
+
+        if response.status_code == 204:
+            return None
+
+        handler = handlers.get(content_type.lower())
+        if handler is None:
+            raise ValueError(f"Invalid Content-Type: {content_type}")
+
+        return handler()
+
+    def _get_http_method(
+        self, method: str
+    ) -> Optional[
+        Callable[..., Optional[Union[Awaitable[Response], Response]]]
+    ]:
+        """
+        Return a callable for making the API call.
+        """
+        if not self.client:
+            raise RuntimeError("HTTP client is not defined")
+
+        method_map = {
+            "GET": self.client.get,
+            "POST": self.client.post,
+            "PUT": self.client.put,
+            "DELETE": self.client.delete,
+        }
+        return method_map.get(method.upper())
+
+    def prepare_headers(
+        self, content_type: str, additional_headers: dict, authenticated: bool
+    ):
+        headers = {
+            "Content-Type": content_type,
+            "Accept": content_type,
+            "User-Agent": self._user_agent,
+        }
+
+        if authenticated:
+            headers["Metadata-Token"] = self._token
+
+        if additional_headers is not None:
+            headers.update(additional_headers)
+
+        return headers
+
+    def prepare_url(self, endpoint: str):
+        return f"{self.base_url}{endpoint}"
+
+    def get_api_call_params(
+        self, url: str, headers: dict, method: str, body: dict
+    ):
+        request_params = {
+            "url": url,
+            "headers": headers,
+            "timeout": self.timeout,
+        }
+
+        if method.lower() in ("put", "post") and body:
+            request_params["data"] = json.dumps(body)
+
+        return request_params
+
+    def check_response(self, response: Response):
+        if 399 < response.status_code < 600:
+            j = None
+            error_msg = f"{response.status_code}: "
+
+            # Don't raise if we don't get JSON back
+            try:
+                j = response.json()
+                if "errors" in j:
+                    error_fragments = [
+                        f"{e['reason']};" for e in j["errors"] if "reason" in e
+                    ]
+                    error_msg += " ".join(error_fragments)
+            except:
+                pass
+
+            raise ApiError(error_msg, status=response.status_code, json=j)
+
+    def set_token(self, token: str):
+        """
+        Sets the passed token as token for client.
+        """
+        self._token = token
+
+    @property
+    def token(self):
+        """
+        Gets the token currently used by this client.
+        """
+        return self._token
+
+    @property
+    def _user_agent(self):
+        append_user_agent = (
+            f"{self._append_user_agent} " if self._append_user_agent else ""
+        )
+        return (
+            f"{append_user_agent} "
+            f"linode-py-metadata/{version('linode_metadata')}"
+        ).strip()
+
+
+class MetadataClient(BaseClient):
     """
     The main interface to the Linode Metadata Service.
 
@@ -70,45 +231,22 @@ class MetadataClient:
         :type managed_token_expiry_seconds: int
         """
 
-        if token is not None and managed_token:
-            raise ValueError(
-                "Token cannot be specified with token management is enabled"
-            )
-
-        self.base_url = base_url
-        self.session = httpx.Client()
-        self._append_user_agent = user_agent
-        self.timeout = timeout
-
-        self._token = token
-
-        self._managed_token = managed_token
-        self._managed_token_expiry_seconds = managed_token_expiry_seconds
-        self._managed_token_expiry = None
-
-        self.check_connection()
-
-        if managed_token:
-            self.refresh_token(
-                expiry_seconds=self._managed_token_expiry_seconds,
-            )
-
-    @property
-    def _user_agent(self):
-        append_user_agent = (
-            f"{self._append_user_agent} " if self._append_user_agent else ""
+        super().__init__(
+            base_url=base_url,
+            user_agent=user_agent,
+            token=token,
+            timeout=timeout,
+            managed_token=managed_token,
+            managed_token_expiry_seconds=managed_token_expiry_seconds,
         )
-        return (
-            f"{append_user_agent} "
-            f"linode-py-metadata/{version('linode_metadata')}"
-        ).strip()
+        self.client = httpx.Client()
 
     def check_connection(self):
         """
         Checks for a connection to the Metadata Service, ensuring customer is inside a Linode.
         """
         try:
-            httpx.get(self.base_url, timeout=self.timeout)
+            self.client.get(self.base_url, timeout=self.timeout)
         except TimeoutException as e:
             raise ApiTimeoutError(
                 "Can't access Metadata service. "
@@ -135,20 +273,6 @@ class MetadataClient:
                 "MetadataClient.refresh_token() to create new token."
             )
 
-    def _get_http_method(
-        self, method: str
-    ) -> Optional[Callable[..., Response]]:
-        """
-        Return a callable for making the API call.
-        """
-        method_map = {
-            "GET": self.session.get,
-            "POST": self.session.post,
-            "PUT": self.session.put,
-            "DELETE": self.session.delete,
-        }
-        return method_map.get(method.upper())
-
     def _api_call(
         self,
         method: str,
@@ -165,67 +289,22 @@ class MetadataClient:
         if method_func is None:
             raise ValueError(f"Invalid API request method: {method}")
 
-        headers = {
-            "Content-Type": content_type,
-            "Accept": content_type,
-            "User-Agent": self._user_agent,
-        }
+        headers = self.prepare_headers(
+            content_type,
+            additional_headers,
+            authenticated,
+        )
 
-        if authenticated:
-            headers["Metadata-Token"] = self._token
+        url = self.prepare_url(endpoint)
+        request_params = self.get_api_call_params(url, headers, method, body)
 
-        if additional_headers is not None:
-            headers.update(additional_headers)
+        response: Response = method_func(**request_params)
 
-        url = f"{self.base_url}{endpoint}"
+        self.check_response(response)
 
-        request_params = {
-            "url": url,
-            "headers": headers,
-            "timeout": self.timeout,
-        }
+        return self._parse_response_body(response, content_type)
 
-        if method.lower() in ("put", "post") and body:
-            request_params["data"] = json.dumps(body)
-
-        resp = method_func(**request_params)
-
-        if 399 < resp.status_code < 600:
-            j = None
-            error_msg = f"{resp.status_code}: "
-
-            # Don't raise if we don't get JSON back
-            try:
-                j = resp.json()
-                if "errors" in j:
-                    error_fragments = [
-                        f"{e['reason']};" for e in j["errors"] if "reason" in e
-                    ]
-                    error_msg += " ".join(error_fragments)
-            except:
-                pass
-
-            raise ApiError(error_msg, status=resp.status_code, json=j)
-
-        return self._parse_response_body(resp, content_type)
-
-    @staticmethod
-    def _parse_response_body(response: Response, content_type: str) -> Any:
-        handlers = {
-            "application/json": response.json,
-            "text/plain": lambda: response.content,
-        }
-
-        if response.status_code == 204:
-            return None
-
-        handler = handlers.get(content_type.lower())
-        if handler is None:
-            raise ValueError(f"Invalid Content-Type: {content_type}")
-
-        return handler()
-
-    def generate_token(self, expiry_seconds=3600) -> MetadataToken:
+    def generate_token(self, expiry_seconds=3600) -> Awaitable[MetadataToken]:
         """
         Generates a token for accessing Metadata Service.
         NOTE: The generated token will NOT be implicitly
@@ -234,7 +313,7 @@ class MetadataClient:
 
         created = datetime.now()
 
-        resp = self._api_call(
+        response = self._api_call(
             "PUT",
             "/token",
             content_type="text/plain",
@@ -245,7 +324,7 @@ class MetadataClient:
         )
 
         return MetadataToken(
-            token=resp, expiry_seconds=expiry_seconds, created=created
+            token=response, expiry_seconds=expiry_seconds, created=created
         )
 
     def refresh_token(self, expiry_seconds: int = 3600) -> MetadataToken:
@@ -262,43 +341,32 @@ class MetadataClient:
 
         return result
 
-    def set_token(self, token: str):
-        """
-        Sets the passed token as token for client.
-        """
-        self._token = token
-
-    @property
-    def token(self):
-        """
-        Gets the token currently used by this client.
-        """
-        return self._token
-
     def get_user_data(self) -> str:
         """
         Returns the user data configured on your running Linode instance.
         """
-        resp = self._api_call("GET", "/user-data", content_type="text/plain")
-        return base64.b64decode(resp).decode("utf-8")
+        response = self._api_call(
+            "GET", "/user-data", content_type="text/plain"
+        )
+        return base64.b64decode(response).decode("utf-8")
 
     def get_instance(self) -> InstanceResponse:
         """
         Returns information about the running Linode instance.
         """
-        resp = self._api_call("GET", "/instance")
-        return InstanceResponse(json_data=resp)
+        response = self._api_call("GET", "/instance")
+        return InstanceResponse(json_data=response)
 
     def get_network(self) -> NetworkResponse:
         """
         Returns information about the running Linode instance’s network configuration.
         """
-        resp = self._api_call("GET", "/network")
-        return NetworkResponse(json_data=resp)
+        response = self._api_call("GET", "/network")
+        return NetworkResponse(json_data=response)
 
     def get_ssh_keys(self) -> SSHKeysResponse:
         """
         Get a mapping of public SSH Keys configured on your running Linode instance.
         """
-        resp = self._api_call("GET", "/ssh-keys")
-        return SSHKeysResponse(json_data=resp)
+        response = self._api_call("GET", "/ssh-keys")
+        return SSHKeysResponse(json_data=response)

--- a/linode_metadata/metadata_client.py
+++ b/linode_metadata/metadata_client.py
@@ -114,13 +114,19 @@ class BaseMetadataClient:
         return method_map.get(method.upper())
 
     def _prepare_headers(
-        self, content_type: str, additional_headers: dict, authenticated: bool
+        self,
+        method: str,
+        content_type: str,
+        additional_headers: dict,
+        authenticated: bool,
     ):
         headers = {
-            "Content-Type": content_type,
             "Accept": content_type,
             "User-Agent": self._user_agent,
         }
+
+        if method.lower() in ("put", "post"):
+            headers["Content-Type"] = content_type
 
         if authenticated:
             headers["Metadata-Token"] = self._token
@@ -285,6 +291,7 @@ class MetadataClient(BaseMetadataClient):
             raise ValueError(f"Invalid API request method: {method}")
 
         headers = self._prepare_headers(
+            method,
             content_type,
             additional_headers,
             authenticated,

--- a/linode_metadata/metadata_client.py
+++ b/linode_metadata/metadata_client.py
@@ -25,6 +25,11 @@ DEFAULT_API_TIMEOUT = 10
 
 
 class BaseMetadataClient:
+    """
+    The base client of Linode Metadata Service that holds shared components
+    between MetadataClient and MetadataAsyncClient.
+    """
+
     def __init__(
         self,
         base_url=BASE_URL,
@@ -108,7 +113,7 @@ class BaseMetadataClient:
         }
         return method_map.get(method.upper())
 
-    def prepare_headers(
+    def _prepare_headers(
         self, content_type: str, additional_headers: dict, authenticated: bool
     ):
         headers = {
@@ -125,10 +130,10 @@ class BaseMetadataClient:
 
         return headers
 
-    def prepare_url(self, endpoint: str):
+    def _prepare_url(self, endpoint: str):
         return f"{self.base_url}{endpoint}"
 
-    def get_api_call_params(
+    def _get_api_call_params(
         self, url: str, headers: dict, method: str, body: dict
     ):
         request_params = {
@@ -142,7 +147,7 @@ class BaseMetadataClient:
 
         return request_params
 
-    def check_response(self, response: Response):
+    def _check_response(self, response: Response):
         if 399 < response.status_code < 600:
             j = None
             error_msg = f"{response.status_code}: "
@@ -186,17 +191,7 @@ class BaseMetadataClient:
 
 class MetadataClient(BaseMetadataClient):
     """
-    The main interface to the Linode Metadata Service.
-
-    :param base_url: The base URL for Metadata API requests.  Generally, you shouldn't
-                     change this.
-    :type base_url: str
-    :param user_agent: What to append to the User Agent of all requests made
-                       by this client.  Setting this allows Linode's internal
-                       monitoring applications to track the usage of your
-                       application.  Setting this is not necessary, but some
-                       applications may desire this behavior.
-    :type user_agent: str
+    The main sync client of the Linode Metadata Service.
     """
 
     def __init__(
@@ -289,18 +284,18 @@ class MetadataClient(BaseMetadataClient):
         if method_func is None:
             raise ValueError(f"Invalid API request method: {method}")
 
-        headers = self.prepare_headers(
+        headers = self._prepare_headers(
             content_type,
             additional_headers,
             authenticated,
         )
 
-        url = self.prepare_url(endpoint)
-        request_params = self.get_api_call_params(url, headers, method, body)
+        url = self._prepare_url(endpoint)
+        request_params = self._get_api_call_params(url, headers, method, body)
 
         response: Response = method_func(**request_params)
 
-        self.check_response(response)
+        self._check_response(response)
 
         return self._parse_response_body(response, content_type)
 

--- a/linode_metadata/metadata_client.py
+++ b/linode_metadata/metadata_client.py
@@ -24,7 +24,7 @@ BASE_URL = "http://169.254.169.254/v1"
 DEFAULT_API_TIMEOUT = 10
 
 
-class BaseClient:
+class BaseMetadataClient:
     def __init__(
         self,
         base_url=BASE_URL,
@@ -184,7 +184,7 @@ class BaseClient:
         ).strip()
 
 
-class MetadataClient(BaseClient):
+class MetadataClient(BaseMetadataClient):
     """
     The main interface to the Linode Metadata Service.
 


### PR DESCRIPTION
## 📝 Description

- `refresh_token()` and `check_connection()` calls have been removed from the constructor (`__init__` magic method) for consisting behavior with the future asynchronous client because a sync method (e.g. `__init__`) in the async client can't call async api call method due to programming language limitation.
- `BaseMetadataClient` has been implemented to contain common components of `MetadataClient` and future `MetadataAsyncClient`.
- `resp` is named to `response` to better align with naming standard in Python community.

## ✔️ How to Test
Since the behavior of `MetadataClient` in this PR should be mostly same as before (except what's described in the first item above), current tests can still verify whether the client is working correctly.

`make e2e`

Manual tests are more complicated since you will have to create a Linode in supported region and run this client in that Linode. On that Linode, you can clone and checkout this branch, and then try [the basic example in the README](https://github.com/linode/py-metadata#basic-example).