### PR TITLE
Implement asyncio and context manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 venv
 .vscode
 .DS_Store
+hack/*_py_metadata_test_report.xml

--- a/linode_metadata/__init__.py
+++ b/linode_metadata/__init__.py
@@ -2,6 +2,5 @@
 Initializes objects for Metadata Client
 """
 
+from linode_metadata.metadata_client import MetadataAsyncClient, MetadataClient
 from linode_metadata.objects import *
-
-from .metadata_client import MetadataClient

--- a/linode_metadata/metadata_client.py
+++ b/linode_metadata/metadata_client.py
@@ -3,14 +3,16 @@ This class provides functions for interacting with the Linode Metadata service.
 It includes methods for retrieving and updating metadata information.
 """
 
+from __future__ import annotations
+
 import base64
-import datetime
 import json
 import logging
 from collections.abc import Awaitable
 from datetime import datetime, timedelta
 from importlib.metadata import version
-from typing import Any, Callable, Optional, Union
+from types import TracebackType
+from typing import Any, Callable, Optional, Type, Union
 
 import httpx
 from httpx import Response, TimeoutException
@@ -119,9 +121,7 @@ class BaseMetadataClient:
 
     def _get_http_method(
         self, method: str
-    ) -> Optional[
-        Callable[..., Optional[Union[Awaitable[Response], Response]]]
-    ]:
+    ) -> Optional[Callable[..., Union[Response, Awaitable[Response]]]]:
         """
         Return a callable for making the API call.
         """
@@ -342,7 +342,7 @@ class MetadataClient(BaseMetadataClient):
         body=None,
         additional_headers=None,
         authenticated=True,
-    ) -> Union[str, dict]:
+    ) -> Any:
         if authenticated:
             self._validate_token()
 
@@ -363,7 +363,7 @@ class MetadataClient(BaseMetadataClient):
         if self._debug:
             self._log_request_debug_info(request_params)
 
-        response: Response = method_func(**request_params)
+        response = method_func(**request_params)
 
         if self._debug:
             self._log_response_debug_info(response)
@@ -372,7 +372,7 @@ class MetadataClient(BaseMetadataClient):
 
         return self._parse_response_body(response, content_type)
 
-    def generate_token(self, expiry_seconds=3600) -> Awaitable[MetadataToken]:
+    def generate_token(self, expiry_seconds=3600) -> MetadataToken:
         """
         Generates a token for accessing Metadata Service.
         NOTE: The generated token will NOT be implicitly
@@ -438,3 +438,227 @@ class MetadataClient(BaseMetadataClient):
         """
         response = self._api_call("GET", "/ssh-keys")
         return SSHKeysResponse(json_data=response)
+
+    def __enter__(self) -> MetadataClient:
+        self.client.__enter__()
+        if self._managed_token:
+            self.refresh_token()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        self._token = None
+        self.client.__exit__(exc_type, exc_value, traceback)
+
+
+class MetadataAsyncClient(BaseMetadataClient):
+    """
+    The main async client of the Linode Metadata Service.
+    """
+
+    def __init__(
+        self,
+        base_url=BASE_URL,
+        user_agent=None,
+        token=None,
+        timeout=DEFAULT_API_TIMEOUT,
+        managed_token=True,
+        managed_token_expiry_seconds=3600,
+        debug=False,
+        debug_file=None,
+    ):
+        """
+        The main interface to the Linode Metadata Service.
+
+        :param base_url: The base URL for Metadata API requests.  Generally, you shouldn't
+                         change this.
+        :type base_url: str
+        :param user_agent: What to append to the User Agent of all requests made
+                           by this client.  Setting this allows Linode's internal
+                           monitoring applications to track the usage of your
+                           application.  Setting this is not necessary, but some
+                           applications may desire this behavior.
+        :type user_agent: str
+        :param token: An existing token to use with this client. This field cannot
+                      be specified when token management is enabled.
+        :type token: Optional[str]
+        :param managed_token: If true, the token for this client will be automatically
+                              generated and refreshed.
+        :type managed_token: bool
+        :param managed_token_expiry_seconds: The number of seconds until a managed token
+                                            should expire. (Default 3600)
+        :type managed_token_expiry_seconds: int
+        :param debug: Enables debug mode if set to True.
+        :type debug: bool
+        :param debug_file: The file location to output the debug logs.
+                            Default to sys.stderr if not specified.
+        :type debug_file: str
+        """
+
+        super().__init__(
+            base_url=base_url,
+            user_agent=user_agent,
+            token=token,
+            timeout=timeout,
+            managed_token=managed_token,
+            managed_token_expiry_seconds=managed_token_expiry_seconds,
+            debug=debug,
+            debug_file=debug_file,
+        )
+        self.client = httpx.AsyncClient()
+
+    async def check_connection(self) -> None:
+        """
+        Checks for a connection to the Metadata Service, ensuring customer is inside a Linode.
+        """
+        try:
+            await self.client.get(self.base_url, timeout=self.timeout)
+        except TimeoutException as e:
+            raise ApiTimeoutError(
+                "Can't access Metadata service. "
+                "Please verify that you are inside a Linode."
+            ) from e
+
+    async def _validate_token(self) -> None:
+        """
+        Check whether the token is valid. Refresh the token if
+        it's expired and managed by this package.
+        """
+        # We should implicitly refresh the token if the user is enrolled in
+        # token management and the token has expired.
+        if self._managed_token and (
+            self._token is None or datetime.now() >= self._managed_token_expiry
+        ):
+            await self.refresh_token(
+                expiry_seconds=self._managed_token_expiry_seconds
+            )
+
+        if self._token is None:
+            raise RuntimeError(
+                "No token provided. Please use "
+                "MetadataClient.refresh_token() to create new token."
+            )
+
+    async def _api_call(
+        self,
+        method: str,
+        endpoint: str,
+        content_type="application/json",
+        body=None,
+        additional_headers=None,
+        authenticated=True,
+    ) -> Any:
+        if authenticated:
+            await self._validate_token()
+
+        method_func = self._get_http_method(method)
+        if method_func is None:
+            raise ValueError(f"Invalid API request method: {method}")
+
+        headers = self._prepare_headers(
+            method,
+            content_type,
+            additional_headers,
+            authenticated,
+        )
+
+        url = self._prepare_url(endpoint)
+        request_params = self._get_api_call_params(url, headers, method, body)
+
+        if self._debug:
+            self._log_request_debug_info(request_params)
+
+        response: Response = await method_func(**request_params)
+
+        if self._debug:
+            self._log_response_debug_info(response)
+
+        self._check_response(response)
+
+        return self._parse_response_body(response, content_type)
+
+    async def generate_token(self, expiry_seconds=3600) -> MetadataToken:
+        """
+        Generates a token for accessing Metadata Service.
+        NOTE: The generated token will NOT be implicitly
+        applied to the MetadataClient.
+        """
+
+        created = datetime.now()
+
+        response = await self._api_call(
+            "PUT",
+            "/token",
+            content_type="text/plain",
+            additional_headers={
+                "Metadata-Token-Expiry-Seconds": str(expiry_seconds)
+            },
+            authenticated=False,
+        )
+
+        return MetadataToken(
+            token=response, expiry_seconds=expiry_seconds, created=created
+        )
+
+    async def refresh_token(self, expiry_seconds: int = 3600) -> MetadataToken:
+        """
+        Regenerates a Metadata Service token.
+        """
+
+        result = await self.generate_token(expiry_seconds=expiry_seconds)
+
+        self.set_token(result.token)
+        self._managed_token_expiry = result.created + timedelta(
+            seconds=expiry_seconds
+        )
+
+        return result
+
+    async def get_user_data(self) -> str:
+        """
+        Returns the user data configured on your running Linode instance.
+        """
+        response = await self._api_call(
+            "GET", "/user-data", content_type="text/plain"
+        )
+        return base64.b64decode(response).decode("utf-8")
+
+    async def get_instance(self) -> InstanceResponse:
+        """
+        Returns information about the running Linode instance.
+        """
+        response = await self._api_call("GET", "/instance")
+        return InstanceResponse(json_data=response)
+
+    async def get_network(self) -> NetworkResponse:
+        """
+        Returns information about the running Linode instance’s network configuration.
+        """
+        response = await self._api_call("GET", "/network")
+        return NetworkResponse(json_data=response)
+
+    async def get_ssh_keys(self) -> SSHKeysResponse:
+        """
+        Get a mapping of public SSH Keys configured on your running Linode instance.
+        """
+        response = await self._api_call("GET", "/ssh-keys")
+        return SSHKeysResponse(json_data=response)
+
+    async def __aenter__(self) -> MetadataAsyncClient:
+        await self.client.__aenter__()
+        if self._managed_token:
+            await self.refresh_token()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ):
+        self._token = None
+        await self.client.__aexit__(exc_type, exc_value, traceback)

--- a/linode_metadata/metadata_client.py
+++ b/linode_metadata/metadata_client.py
@@ -17,9 +17,9 @@ from typing import Any, Callable, Optional, Type, Union
 import httpx
 from httpx import Response, TimeoutException
 
-from linode_metadata import NetworkResponse
 from linode_metadata.objects.error import ApiError, ApiTimeoutError
 from linode_metadata.objects.instance import InstanceResponse
+from linode_metadata.objects.networking import NetworkResponse
 from linode_metadata.objects.ssh_keys import SSHKeysResponse
 from linode_metadata.objects.token import MetadataToken
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = ["httpx"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["pytest", "black", "isort", "pylint", "autoflake", "Sphinx>=7.2.6"]
+dev = ["pytest", "black", "isort", "pylint", "autoflake", "Sphinx>=7.2.6", "pytest-asyncio"]
 
 [project.urls]
 homepage = "https://github.com/linode/py-metadata"

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,17 +1,28 @@
 import pytest
+import pytest_asyncio
 
-import linode_metadata
-
-
-@pytest.fixture(scope="function")
-def metadata_client():
-    client = linode_metadata.MetadataClient()
-    return client
+from linode_metadata import MetadataAsyncClient, MetadataClient
 
 
-@pytest.fixture(scope="function")
-def metadata_client_unmanaged():
-    client = linode_metadata.MetadataClient(
-        managed_token=False,
-    )
-    return client
+@pytest.fixture(scope="session")
+def client():
+    with MetadataClient() as client:
+        yield client
+
+
+@pytest_asyncio.fixture()
+async def async_client():
+    async with MetadataAsyncClient() as async_client:
+        yield async_client
+
+
+@pytest.fixture(scope="session")
+def client_unmanaged():
+    with MetadataClient(managed_token=False) as client:
+        yield client
+
+
+@pytest_asyncio.fixture()
+async def async_client_unmanaged():
+    async with MetadataAsyncClient(managed_token=False) as async_client:
+        yield async_client

--- a/test/integration/test_instance.py
+++ b/test/integration/test_instance.py
@@ -1,9 +1,23 @@
 import re
 
+import pytest
 
-def test_get_instance_info(metadata_client):
-    instance = metadata_client.get_instance()
+from linode_metadata import MetadataAsyncClient, MetadataClient
+from linode_metadata.objects.instance import InstanceResponse
 
+
+def test_get_instance_info(client: MetadataClient):
+    instance = client.get_instance()
+    inspect_instance_response(instance)
+
+
+@pytest.mark.asyncio
+async def test_async_get_instance_info(async_client: MetadataAsyncClient):
+    instance = await async_client.get_instance()
+    inspect_instance_response(instance)
+
+
+def inspect_instance_response(instance: InstanceResponse):
     assert isinstance(instance.id, int)
     assert re.match(r"^[A-Za-z\-0-9]+$", instance.label)
     assert re.match(r"^[a-z\-]+$", instance.region)

--- a/test/integration/test_network.py
+++ b/test/integration/test_network.py
@@ -1,10 +1,27 @@
 import re
 
-from linode_metadata.objects.networking import IPv4Networking, IPv6Networking
+import pytest
+
+from linode_metadata import MetadataAsyncClient, MetadataClient
+from linode_metadata.objects.networking import (
+    IPv4Networking,
+    IPv6Networking,
+    NetworkResponse,
+)
 
 
-def test_get_network_info(metadata_client):
-    network = metadata_client.get_network()
+def test_get_network_info(client: MetadataClient):
+    network = client.get_network()
+    inspect_network_response(network)
+
+
+@pytest.mark.asyncio
+async def test_async_get_network_info(async_client: MetadataAsyncClient):
+    network = await async_client.get_network()
+    inspect_network_response(network)
+
+
+def inspect_network_response(network: NetworkResponse):
 
     assert isinstance(network.interfaces, list)
     assert isinstance(network.ipv4, IPv4Networking)

--- a/test/integration/test_ssh.py
+++ b/test/integration/test_ssh.py
@@ -2,13 +2,25 @@ import re
 
 import pytest
 
+from linode_metadata import MetadataAsyncClient, MetadataClient
+from linode_metadata.objects.ssh_keys import SSHKeysResponse
 
-def test_get_ssh_keys(metadata_client):
-    ssh = metadata_client.get_ssh_keys()
 
+def test_get_ssh_keys(client: MetadataClient):
+    ssh_keys = client.get_ssh_keys()
+    inspect_ssh_keys_response(ssh_keys)
+
+
+@pytest.mark.asyncio
+async def test_get_ssh_keys(async_client: MetadataAsyncClient):
+    ssh_keys = await async_client.get_ssh_keys()
+    inspect_ssh_keys_response(ssh_keys)
+
+
+def inspect_ssh_keys_response(ssh_keys: SSHKeysResponse):
     # In some cases we may not have an authorized key
     # configured for root
-    if len(ssh.users) < 1:
+    if len(ssh_keys.users) < 1:
         pytest.skip(
             "The current instance does not have any any SSH keys configured, skipping..."
         )
@@ -17,7 +29,7 @@ def test_get_ssh_keys(metadata_client):
         r"^ssh-(?:rsa|ed25519|ecdsa|dss)\s[A-Za-z0-9+/]+[=]*\s\S*$"
     )
 
-    for name, user in ssh.users.items():
+    for name, user in ssh_keys.users.items():
         assert isinstance(name, str)
 
         for key in user:

--- a/test/integration/test_token.py
+++ b/test/integration/test_token.py
@@ -1,41 +1,65 @@
+import asyncio
 import time
 from datetime import datetime
 
 import pytest
 
 import linode_metadata
+from linode_metadata import MetadataClient
+from linode_metadata.metadata_client import MetadataAsyncClient
 from linode_metadata.objects.error import ApiError
+from linode_metadata.objects.token import MetadataToken
 
 
-def test_generate_and_use_new_metadata_token(metadata_client_unmanaged):
-    client = metadata_client_unmanaged
+@pytest.fixture
+def invalid_token():
+    return "1234randominvalidtoken"
+
+
+def inspect_token(token: MetadataToken):
+    assert isinstance(token.token, bytes)
+    assert isinstance(token.expiry_seconds, int)
+    assert isinstance(token.created, datetime)
+
+    assert len(token.token) == 64
+
+    assert token.expiry_seconds == 3600
+
+
+def test_generate_and_use_new_metadata_token(client_unmanaged: MetadataClient):
+    client = client_unmanaged
 
     new_token = client.generate_token()
-
-    assert isinstance(new_token.token, bytes)
-    assert isinstance(new_token.expiry_seconds, int)
-    assert isinstance(new_token.created, datetime)
-
-    assert len(new_token.token) == 64
-
-    assert new_token.expiry_seconds == 3600
+    inspect_token(new_token)
 
     client.set_token(token=new_token.token)
 
     # try sending api request using new token
-    try:
-        network = client.get_network()
-        assert network is not None
-    except ApiError as err:
-        raise err
+    network = client.get_network()
+    assert network is not None
+
+
+@pytest.mark.asyncio
+async def test_generate_and_use_new_metadata_token_async(
+    async_client_unmanaged: MetadataAsyncClient,
+):
+    client = async_client_unmanaged
+
+    new_token = await client.generate_token()
+    inspect_token(new_token)
+
+    client.set_token(token=new_token.token)
+
+    # try sending api request using new token
+    network = await client.get_network()
+    assert network is not None
 
 
 def test_verify_error_thrown_when_using_invalid_api_token(
-    metadata_client_unmanaged,
+    client_unmanaged: MetadataClient,
+    invalid_token: str,
 ):
-    invalid_token = "1234randominvalidtoken"
-
-    client = metadata_client_unmanaged
+    client = client_unmanaged
 
     client.set_token(token=invalid_token)
 
@@ -48,15 +72,33 @@ def test_verify_error_thrown_when_using_invalid_api_token(
     # refresh token and verify connection don't throw error after
     client.refresh_token()
 
-    try:
-        network = client.get_network()
-        assert network is not None
-    except ApiError as err:
-        raise err
+    network = client.get_network()
+    assert network is not None
 
 
-def test_unmanaged_token_expire(metadata_client_unmanaged):
-    client = metadata_client_unmanaged
+@pytest.mark.asyncio
+async def test_verify_error_thrown_when_using_invalid_api_token_async(
+    async_client_unmanaged: MetadataAsyncClient, invalid_token: str
+):
+    client = async_client_unmanaged
+
+    client.set_token(token=invalid_token)
+
+    with pytest.raises(ApiError) as excinfo:
+        await client.get_network()
+
+    assert excinfo.value.status == 401
+    assert "Unauthorized" in str(excinfo.value.json)
+
+    # refresh token and verify connection don't throw error after
+    await client.refresh_token()
+
+    network = await client.get_network()
+    assert network is not None
+
+
+def test_unmanaged_token_expire(client_unmanaged: MetadataClient):
+    client = client_unmanaged
 
     client.refresh_token(expiry_seconds=1)
 
@@ -64,6 +106,22 @@ def test_unmanaged_token_expire(metadata_client_unmanaged):
 
     with pytest.raises(ApiError) as excinfo:
         client.get_network()
+
+    assert excinfo.value.status == 401
+    assert "Unauthorized" in str(excinfo.value.json)
+
+
+@pytest.mark.asyncio
+async def test_unmanaged_token_expire_async(
+    async_client_unmanaged: MetadataAsyncClient,
+):
+    client = async_client_unmanaged
+
+    await client.refresh_token(expiry_seconds=1)
+    await asyncio.sleep(2)
+
+    with pytest.raises(ApiError) as excinfo:
+        await client.get_network()
 
     assert excinfo.value.status == 401
     assert "Unauthorized" in str(excinfo.value.json)
@@ -82,4 +140,21 @@ def test_managed_token_auto_refresh():
 
     # Ensure the token is automatically refreshed
     networking = client.get_network()
+    assert networking is not None
+
+
+@pytest.mark.asyncio
+async def test_managed_token_auto_refresh_async():
+    client = linode_metadata.MetadataAsyncClient(
+        managed_token_expiry_seconds=1,
+    )
+
+    # Ensure the initial token is generated properly
+    instance = await client.get_instance()
+    assert instance is not None
+
+    asyncio.sleep(2)
+
+    # Ensure the token is automatically refreshed
+    networking = await client.get_network()
     assert networking is not None


### PR DESCRIPTION
## 📝 Description

You can now use the async client with context manager:

```python
async with MetadataAsyncClient() as async_client:
    instance = await async_client.get_instance()
    print(instance)  
```

or sync client with context manager:

```python
with MetadataClient() as client:
    instance = async_client.get_instance()
    print(instance)  
```

The asynchronous client generally has a better performance because it won't require creating a new thread for non-blocking API call.

## ✔️ How to Test
`make e2e`