### PR TITLE
Fix E2E Workflow

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -31,16 +31,13 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: update packages
-        run: sudo apt-get update -y
-
       - name: setup python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: install or update Python build system
-        run: python3 -m pip install -U wheel setuptools certifi pip
+        run: python3 -m pip install -U wheel setuptools certifi pip boto3
 
       - name: install test dependencies
         run: make test-deps


### PR DESCRIPTION
- Removed unnecessary step: `update packages`
- Always install latest Python version
- Install boto3 for TOD upload

GHA run: https://github.com/linode/py-metadata/actions/runs/8145371071/job/22261460808
(No other tests needed)