### PR TITLE
doc: Fix SSH key example in README; swap _ with - in pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package allows Python projects to easily interact with the [Linode Metadata
 ### Installation
 
 ```bash
-pip install linode_metadata
+pip install linode-metadata
 ```
 
 ### Building from Source
@@ -46,7 +46,7 @@ user_data = client.get_user_data()
 
 print("Instance ID:", instance_info.id)
 print("Public IPv4:", network_info.ipv4.public[0])
-print("SSH Keys:", "; ".join(ssh_info.users.root))
+print("SSH Keys:", "; ".join(ssh_info.users))
 print("User Data:", user_data)
 ```
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,9 +11,9 @@ This library can be used to interact with the Metadata Service API.
 Installation
 ------------
 
-To install through pypi::
+To install through PyPI::
 
-   pip install linode_metadata
+   pip install linode-metadata
 
 To install from source::
 


### PR DESCRIPTION
## 📝 Description

This change corrects the following documentation errors:

* The SSH key example in the README referenced the root user using the old-style reference format, which has since been replaced with a dict
* The `pip install` examples have been swapped from `linode_metadata` to `linode-metadata`
    * Pip automatically replaces _'s with -'s, but we can reduce user confusion by ensuring the install command lines up with what is shown on PyPI

## ✔️ How to Test

N/A