### PR TITLE
Require Python 3.9 as 3.8 is now EOL

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9','3.10','3.11', '3.12' ]
+        python-version: [ '3.9','3.10','3.11', '3.12', '3.13' ]
     steps:
       - name: checkout repo
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package allows Python projects to easily interact with the [Linode Metadata
 
 ### Prerequisites
 
-- Python >= 3.8
+- Python >= 3.9
 - A running [Linode Instance](https://www.linode.com/docs/api/linode-instances/)
 
 ### Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "linode_metadata"
 authors = [{ name = "Linode", email = "developers@linode.com" }]
 description = "A client to interact with the Linode Metadata service in Python."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "BSD-3-Clause" }
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -17,11 +17,11 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = ["httpx"]
 dynamic = ["version"]
@@ -56,7 +56,7 @@ line_length = 80
 
 [tool.black]
 line-length = 80
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 [tool.autoflake]
 expand-star-imports = true


### PR DESCRIPTION
Python 3.8 has been EOL, upgrading min version requirement to 3.9