### PR TITLE
Add a specific environment for PyPI publisher

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -8,6 +8,7 @@ on:
     types: [ published ]
 jobs:
   pypi-release:
+    environment: pypi-release
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write


### PR DESCRIPTION
## 📝 Description

Add an environment to the repository and the workflow to enhance security and ability to add more protection rules.
