### PR TITLE
Align GHA workflows in the scope of report uploads

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -19,9 +19,12 @@ on:
           - 'false'
       test_report_upload:
         description: 'Indicates whether to upload the test report to object storage. Defaults to "false"'
-        type: boolean
+        type: choice
         required: false
-        default: false
+        default: 'false'
+        options:
+          - 'true'
+          - 'false'
   push:
     branches:
       - main
@@ -71,7 +74,7 @@ jobs:
           cp hack/*_py_metadata_test_report.xml .
 
       - name: Add variables and upload test results
-        if: ${{ always() && github.repository == 'linode/py-metadata' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload)) }}
+        if: always() && github.repository == 'linode/py-metadata' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload == 'true'))
         run: |
           filename=$(ls | grep -E '^[0-9]{12}_py_metadata_test_report\.xml$')
           python3 e2e_scripts/tod_scripts/xml_to_obj_storage/scripts/add_gha_info_to_xml.py \

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -17,6 +17,11 @@ on:
         options:
           - 'true'
           - 'false'
+      test_report_upload:
+        description: 'Indicates whether to upload the test report to object storage. Defaults to "false"'
+        type: boolean
+        required: false
+        default: false
   push:
     branches:
       - main
@@ -66,7 +71,7 @@ jobs:
           cp hack/*_py_metadata_test_report.xml .
 
       - name: Add variables and upload test results
-        if: always() && github.event_name == 'push'
+        if: ${{ always() && github.repository == 'linode/py-metadata' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload)) }}
         run: |
           filename=$(ls | grep -E '^[0-9]{12}_py_metadata_test_report\.xml$')
           python3 e2e_scripts/tod_scripts/xml_to_obj_storage/scripts/add_gha_info_to_xml.py \

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -65,8 +65,8 @@ jobs:
           ls -l hack/
           cp hack/*_py_metadata_test_report.xml .
 
-      - name: Copy report to root and Upload test results
-        if: always()
+      - name: Add variables and upload test results
+        if: always() && github.event_name == 'push'
         run: |
           filename=$(ls | grep -E '^[0-9]{12}_py_metadata_test_report\.xml$')
           python3 e2e_scripts/tod_scripts/xml_to_obj_storage/scripts/add_gha_info_to_xml.py \


### PR DESCRIPTION
## 📝 Description

GHA workflows upload test results to TOD on push, PR and manual (workflow_dispatch) runs. PR covers aligning integration test workflows to upload results automatically on push and on demand for manual runs.

https://track.akamai.com/jira/browse/TPT-4190

## ✔️ How to Test
Manual run of the workflow should not upload test results to TOD by default.