### PR TITLE
TPT-4318: Add @linode/dx-sdets to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @linode/dx
-* @linode/dx-sdets
+* @linode/dx @linode/dx-sdets

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @linode/dx
+* @linode/dx-sdets


### PR DESCRIPTION
This PR adds the @linode/dx-sdets team to the CODEOWNERS file as part of the new review auto-assignment workflow.